### PR TITLE
fix(gitignore): scope runtime data ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,10 @@ outputs/
 wandb/
 
 # Downloaded datasets and local media
-data/
-datasets/
+/data/
+/datasets/
+/mmeb_v3_eval/data/
+/mmeb_v3_eval/datasets/
 *.tar
 *.tar.gz
 *.zip


### PR DESCRIPTION
## Summary

- Anchor the repository-root runtime dataset ignore rules.
- Preserve the MMEB-v3 runtime data exclusions.
- Prevent unrelated nested directories named `data` or `datasets` from being silently ignored.

## Rationale

Gitignore directory patterns without a leading slash match at any depth. The existing rules therefore also exclude nested source directories with the same names.

## Validation

- Verified root `data/` and `datasets/` remain ignored.
- Verified `mmeb_v3_eval/data/` and `mmeb_v3_eval/datasets/` remain ignored.
- Verified nested `package/data/` and `package/datasets/` source paths are not ignored.
- Verified `__pycache__/` remains ignored.
- Ran `git diff --check`.