### PR TITLE
Fix grammar: subject-verb agreement (MODALITIES...exclude)

### DIFF
--- a/mmeb_v3_eval/README.md
+++ b/mmeb_v3_eval/README.md
@@ -107,7 +107,7 @@ datasets are skipped on re-run (embedding pickles are reused).
 ## Notes & limitations
 
 - **Audio tasks are not supported** (WeMM-Embedding has no audio tower). The
-  default `MODALITIES` in the run scripts therefore excludes `audio`.
+  default `MODALITIES` in the run scripts therefore exclude `audio`.
 - `<embedding>` token: appended automatically by the model-side chat
   template / tokenizer post-processor — do not insert it manually.
 - Video inputs follow the WeMM frame-bundle convention: `video_grid_thw` is


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `mmeb_v3_eval/README.md` (line 110).

## Problem

Subject-verb agreement: 'MODALITIES' is plural but 'excludes' is singular. Should be 'exclude'.

The problematic text:

```markdown
The default `MODALITIES` in the run scripts therefore excludes `audio`.
```

## Fix

Replaced with:

```markdown
The default `MODALITIES` in the run scripts therefore exclude `audio`.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text