### PR TITLE
Fix grammar: missing article before 'citation'

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ OUTPUT_DIR=exps/wemm_embedding bash scripts/run_eval.sh
 ```
 
 ## Citation
-If you find this repository useful, please consider giving a star ⭐ and citation
+If you find this repository useful, please consider giving a star ⭐ and a citation
 ```bibtex
 @article{wemm-embedding,
       title={WeMM-Embedding: WeChat Multi-Modal Embedding Technical Report}, 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 161).

## Problem

Missing article 'a' before 'citation'. The first object 'a star' has the article, but 'citation' does not.

The problematic text:

```markdown
please consider giving a star and citation
```

## Fix

Replaced with:

```markdown
please consider giving a star and a citation
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text